### PR TITLE
Merge to prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"tailwind-variants": "^0.3.1",
 		"tailwindcss": "^3.4.17",
 		"tailwindcss-animate": "^1.0.7",
-		"typescript": "^5.7.3",
+		"typescript": "^5.8.2",
 		"vaul-svelte": "1.0.0-next.6",
 		"vite": "^6.2.0"
 	},

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"prettier": "^3.5.2",
 		"prettier-plugin-svelte": "^3.3.3",
 		"prettier-plugin-tailwindcss": "^0.6.11",
-		"svelte": "^5.20.5",
+		"svelte": "^5.22.5",
 		"svelte-check": "^4.1.4",
 		"svelte-seo": "^1.6.1",
 		"svelte-sonner": "^0.3.28",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@sveltejs/kit": "^2.17.3",
 		"@sveltejs/vite-plugin-svelte": "^5.0.3",
 		"autoprefixer": "^10.4.20",
-		"bits-ui": "1.3.2",
+		"bits-ui": "1.3.4",
 		"clsx": "^2.1.1",
 		"embla-carousel-svelte": "^8.5.2",
 		"lucide-svelte": "^0.476.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"bits-ui": "1.3.2",
 		"clsx": "^2.1.1",
 		"embla-carousel-svelte": "^8.5.2",
-		"lucide-svelte": "^0.475.0",
+		"lucide-svelte": "^0.476.0",
 		"mdsvex": "^0.12.3",
 		"mode-watcher": "^0.5.1",
 		"prettier": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"vite": "^6.2.0"
 	},
 	"dependencies": {
-		"@fontsource/inter": "^5.1.1",
+		"@fontsource/inter": "^5.2.5",
 		"embla-carousel-autoplay": "^8.5.2",
 		"embla-carousel-class-names": "^8.5.2",
 		"embla-carousel-wheel-gestures": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"lucide-svelte": "^0.476.0",
 		"mdsvex": "^0.12.3",
 		"mode-watcher": "^0.5.1",
-		"prettier": "^3.5.2",
+		"prettier": "^3.5.3",
 		"prettier-plugin-svelte": "^3.3.3",
 		"prettier-plugin-tailwindcss": "^0.6.11",
 		"svelte": "^5.22.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"bits-ui": "1.3.4",
 		"clsx": "^2.1.1",
 		"embla-carousel-svelte": "^8.5.2",
-		"lucide-svelte": "^0.476.0",
+		"lucide-svelte": "^0.479.0",
 		"mdsvex": "^0.12.3",
 		"mode-watcher": "^0.5.1",
 		"prettier": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"embla-carousel-class-names": "^8.5.2",
 		"embla-carousel-wheel-gestures": "^8.0.1",
 		"gsap": "^3.12.7",
-		"posthog-js": "^1.224.0",
+		"posthog-js": "^1.227.0",
 		"svelte-material-icons": "^3.0.5"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,65 +28,65 @@ importers:
         version: 1.227.0(@rrweb/types@2.0.0-alpha.17)
       svelte-material-icons:
         specifier: ^3.0.5
-        version: 3.0.5(svelte@5.20.5)
+        version: 3.0.5(svelte@5.22.5)
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^4.0.0
-        version: 4.0.0(@sveltejs/kit@2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))
+        version: 4.0.0(@sveltejs/kit@2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))
       '@sveltejs/adapter-cloudflare':
         specifier: ^5.0.3
-        version: 5.0.3(@sveltejs/kit@2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(wrangler@3.109.1(@cloudflare/workers-types@4.20250224.0))
+        version: 5.0.3(@sveltejs/kit@2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(wrangler@3.109.1(@cloudflare/workers-types@4.20250224.0))
       '@sveltejs/enhanced-img':
         specifier: ^0.4.4
-        version: 0.4.4(rollup@4.34.8)(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
+        version: 0.4.4(rollup@4.34.8)(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
       '@sveltejs/kit':
         specifier: ^2.17.3
-        version: 2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
+        version: 2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.3
-        version: 5.0.3(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
+        version: 5.0.3(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.5.3)
       bits-ui:
         specifier: 1.3.4
-        version: 1.3.4(svelte@5.20.5)
+        version: 1.3.4(svelte@5.22.5)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
       embla-carousel-svelte:
         specifier: ^8.5.2
-        version: 8.5.2(svelte@5.20.5)
+        version: 8.5.2(svelte@5.22.5)
       lucide-svelte:
         specifier: ^0.476.0
-        version: 0.476.0(svelte@5.20.5)
+        version: 0.476.0(svelte@5.22.5)
       mdsvex:
         specifier: ^0.12.3
-        version: 0.12.3(svelte@5.20.5)
+        version: 0.12.3(svelte@5.22.5)
       mode-watcher:
         specifier: ^0.5.1
-        version: 0.5.1(svelte@5.20.5)
+        version: 0.5.1(svelte@5.22.5)
       prettier:
         specifier: ^3.5.2
         version: 3.5.2
       prettier-plugin-svelte:
         specifier: ^3.3.3
-        version: 3.3.3(prettier@3.5.2)(svelte@5.20.5)
+        version: 3.3.3(prettier@3.5.2)(svelte@5.22.5)
       prettier-plugin-tailwindcss:
         specifier: ^0.6.11
-        version: 0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.2)(svelte@5.20.5))(prettier@3.5.2)
+        version: 0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.2)(svelte@5.22.5))(prettier@3.5.2)
       svelte:
-        specifier: ^5.20.5
-        version: 5.20.5
+        specifier: ^5.22.5
+        version: 5.22.5
       svelte-check:
         specifier: ^4.1.4
-        version: 4.1.4(picomatch@4.0.2)(svelte@5.20.5)(typescript@5.7.3)
+        version: 4.1.4(picomatch@4.0.2)(svelte@5.22.5)(typescript@5.7.3)
       svelte-seo:
         specifier: ^1.6.1
         version: 1.6.1(typescript@5.7.3)
       svelte-sonner:
         specifier: ^0.3.28
-        version: 0.3.28(svelte@5.20.5)
+        version: 0.3.28(svelte@5.22.5)
       tailwind-merge:
         specifier: ^3.0.2
         version: 3.0.2
@@ -104,7 +104,7 @@ importers:
         version: 5.7.3
       vaul-svelte:
         specifier: 1.0.0-next.6
-        version: 1.0.0-next.6(svelte@5.20.5)
+        version: 1.0.0-next.6(svelte@5.22.5)
       vite:
         specifier: ^6.2.0
         version: 6.2.0(jiti@1.21.7)(yaml@2.7.0)
@@ -880,6 +880,11 @@ packages:
   '@rrweb/types@2.0.0-alpha.17':
     resolution: {integrity: sha512-AfDTVUuCyCaIG0lTSqYtrZqJX39ZEYzs4fYKnexhQ+id+kbZIpIJtaut5cto6dWZbB3SEe4fW0o90Po3LvTmfg==}
 
+  '@sveltejs/acorn-typescript@1.0.5':
+    resolution: {integrity: sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@sveltejs/adapter-auto@4.0.0':
     resolution: {integrity: sha512-kmuYSQdD2AwThymQF0haQhM8rE5rhutQXG4LNbnbShwhMO4qQGnKaaTy+88DuNSuoQDi58+thpq8XpHc1+oEKQ==}
     peerDependencies:
@@ -933,17 +938,17 @@ packages:
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
-  acorn-typescript@1.4.13:
-    resolution: {integrity: sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==}
-    peerDependencies:
-      acorn: '>=8.9.0'
-
   acorn-walk@8.3.2:
     resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
     engines: {node: '>=0.4.0'}
 
   acorn@8.14.0:
     resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.14.1:
+    resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -1757,8 +1762,8 @@ packages:
     peerDependencies:
       svelte: ^5.0.0
 
-  svelte@5.20.5:
-    resolution: {integrity: sha512-dpu2lTPVsAAgZFKpF7A9741sBCdXGogfxFU4aQeVgun7GVNCSVheTzj0FsT7g9OsLhBaMX4lKLwVIvmzQGytmQ==}
+  svelte@5.22.5:
+    resolution: {integrity: sha512-+2BDWVa/rqr34oM+5HFUSmCCPdBBeNqFv2Xc/SSB8kV4iQhWWBNvU9/nd5Dz3PkAGl7Bm/AndS1vY4fe1MgTKA==}
     engines: {node: '>=18'}
 
   tabbable@6.2.0:
@@ -2436,34 +2441,38 @@ snapshots:
     dependencies:
       rrweb-snapshot: 2.0.0-alpha.18
 
-  '@sveltejs/adapter-auto@4.0.0(@sveltejs/kit@2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))':
+  '@sveltejs/acorn-typescript@1.0.5(acorn@8.14.1)':
     dependencies:
-      '@sveltejs/kit': 2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
+      acorn: 8.14.1
+
+  '@sveltejs/adapter-auto@4.0.0(@sveltejs/kit@2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))':
+    dependencies:
+      '@sveltejs/kit': 2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-cloudflare@5.0.3(@sveltejs/kit@2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(wrangler@3.109.1(@cloudflare/workers-types@4.20250224.0))':
+  '@sveltejs/adapter-cloudflare@5.0.3(@sveltejs/kit@2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(wrangler@3.109.1(@cloudflare/workers-types@4.20250224.0))':
     dependencies:
       '@cloudflare/workers-types': 4.20250224.0
-      '@sveltejs/kit': 2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/kit': 2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
       esbuild: 0.24.2
       worktop: 0.8.0-next.18
       wrangler: 3.109.1(@cloudflare/workers-types@4.20250224.0)
 
-  '@sveltejs/enhanced-img@0.4.4(rollup@4.34.8)(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))':
+  '@sveltejs/enhanced-img@0.4.4(rollup@4.34.8)(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
       magic-string: 0.30.17
       sharp: 0.33.5
-      svelte: 5.20.5
-      svelte-parse-markup: 0.1.5(svelte@5.20.5)
+      svelte: 5.22.5
+      svelte-parse-markup: 0.1.5(svelte@5.22.5)
       vite: 6.2.0(jiti@1.21.7)(yaml@2.7.0)
       vite-imagetools: 7.0.5(rollup@4.34.8)
       zimmerframe: 1.1.2
     transitivePeerDependencies:
       - rollup
 
-  '@sveltejs/kit@2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))':
+  '@sveltejs/kit@2.17.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -2475,26 +2484,26 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.7.1
       sirv: 3.0.1
-      svelte: 5.20.5
+      svelte: 5.22.5
       vite: 6.2.0(jiti@1.21.7)(yaml@2.7.0)
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
       debug: 4.4.0
-      svelte: 5.20.5
+      svelte: 5.22.5
       vite: 6.2.0(jiti@1.21.7)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.22.5)(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
-      svelte: 5.20.5
+      svelte: 5.22.5
       vite: 6.2.0(jiti@1.21.7)(yaml@2.7.0)
       vitefu: 1.0.6(vite@6.2.0(jiti@1.21.7)(yaml@2.7.0))
     transitivePeerDependencies:
@@ -2510,13 +2519,11 @@ snapshots:
 
   '@types/unist@2.0.11': {}
 
-  acorn-typescript@1.4.13(acorn@8.14.0):
-    dependencies:
-      acorn: 8.14.0
-
   acorn-walk@8.3.2: {}
 
   acorn@8.14.0: {}
+
+  acorn@8.14.1: {}
 
   ansi-regex@5.0.1: {}
 
@@ -2559,15 +2566,15 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  bits-ui@1.3.4(svelte@5.20.5):
+  bits-ui@1.3.4(svelte@5.22.5):
     dependencies:
       '@floating-ui/core': 1.6.9
       '@floating-ui/dom': 1.6.13
       '@internationalized/date': 3.7.0
       esm-env: 1.2.2
-      runed: 0.23.4(svelte@5.20.5)
-      svelte: 5.20.5
-      svelte-toolbelt: 0.7.1(svelte@5.20.5)
+      runed: 0.23.4(svelte@5.22.5)
+      svelte: 5.22.5
+      svelte-toolbelt: 0.7.1(svelte@5.22.5)
       tabbable: 6.2.0
 
   blake3-wasm@2.1.5: {}
@@ -2677,11 +2684,11 @@ snapshots:
     dependencies:
       embla-carousel: 8.5.2
 
-  embla-carousel-svelte@8.5.2(svelte@5.20.5):
+  embla-carousel-svelte@8.5.2(svelte@5.22.5):
     dependencies:
       embla-carousel: 8.5.2
       embla-carousel-reactive-utils: 8.5.2(embla-carousel@8.5.2)
-      svelte: 5.20.5
+      svelte: 5.22.5
 
   embla-carousel-wheel-gestures@8.0.1(embla-carousel@8.5.2):
     dependencies:
@@ -2905,9 +2912,9 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lucide-svelte@0.476.0(svelte@5.20.5):
+  lucide-svelte@0.476.0(svelte@5.22.5):
     dependencies:
-      svelte: 5.20.5
+      svelte: 5.22.5
 
   magic-string@0.25.9:
     dependencies:
@@ -2917,12 +2924,12 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  mdsvex@0.12.3(svelte@5.20.5):
+  mdsvex@0.12.3(svelte@5.22.5):
     dependencies:
       '@types/unist': 2.0.11
       prism-svelte: 0.4.7
       prismjs: 1.29.0
-      svelte: 5.20.5
+      svelte: 5.22.5
       vfile-message: 2.0.4
 
   merge2@1.4.1: {}
@@ -2959,14 +2966,14 @@ snapshots:
 
   mlly@1.7.4:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.14.1
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.5.4
 
-  mode-watcher@0.5.1(svelte@5.20.5):
+  mode-watcher@0.5.1(svelte@5.22.5):
     dependencies:
-      svelte: 5.20.5
+      svelte: 5.22.5
 
   mri@1.2.0: {}
 
@@ -3076,16 +3083,16 @@ snapshots:
 
   preact@10.26.4: {}
 
-  prettier-plugin-svelte@3.3.3(prettier@3.5.2)(svelte@5.20.5):
+  prettier-plugin-svelte@3.3.3(prettier@3.5.2)(svelte@5.22.5):
     dependencies:
       prettier: 3.5.2
-      svelte: 5.20.5
+      svelte: 5.22.5
 
-  prettier-plugin-tailwindcss@0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.2)(svelte@5.20.5))(prettier@3.5.2):
+  prettier-plugin-tailwindcss@0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.2)(svelte@5.22.5))(prettier@3.5.2):
     dependencies:
       prettier: 3.5.2
     optionalDependencies:
-      prettier-plugin-svelte: 3.3.3(prettier@3.5.2)(svelte@5.20.5)
+      prettier-plugin-svelte: 3.3.3(prettier@3.5.2)(svelte@5.22.5)
 
   prettier@3.5.2: {}
 
@@ -3164,10 +3171,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  runed@0.23.4(svelte@5.20.5):
+  runed@0.23.4(svelte@5.22.5):
     dependencies:
       esm-env: 1.2.2
-      svelte: 5.20.5
+      svelte: 5.22.5
 
   sade@1.8.1:
     dependencies:
@@ -3274,25 +3281,25 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.1.4(picomatch@4.0.2)(svelte@5.20.5)(typescript@5.7.3):
+  svelte-check@4.1.4(picomatch@4.0.2)(svelte@5.22.5)(typescript@5.7.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.3
       fdir: 6.4.3(picomatch@4.0.2)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.20.5
+      svelte: 5.22.5
       typescript: 5.7.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-material-icons@3.0.5(svelte@5.20.5):
+  svelte-material-icons@3.0.5(svelte@5.22.5):
     dependencies:
-      svelte: 5.20.5
+      svelte: 5.22.5
 
-  svelte-parse-markup@0.1.5(svelte@5.20.5):
+  svelte-parse-markup@0.1.5(svelte@5.22.5):
     dependencies:
-      svelte: 5.20.5
+      svelte: 5.22.5
 
   svelte-seo@1.6.1(typescript@5.7.3):
     dependencies:
@@ -3300,24 +3307,24 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  svelte-sonner@0.3.28(svelte@5.20.5):
+  svelte-sonner@0.3.28(svelte@5.22.5):
     dependencies:
-      svelte: 5.20.5
+      svelte: 5.22.5
 
-  svelte-toolbelt@0.7.1(svelte@5.20.5):
+  svelte-toolbelt@0.7.1(svelte@5.22.5):
     dependencies:
       clsx: 2.1.1
-      runed: 0.23.4(svelte@5.20.5)
+      runed: 0.23.4(svelte@5.22.5)
       style-to-object: 1.0.8
-      svelte: 5.20.5
+      svelte: 5.22.5
 
-  svelte@5.20.5:
+  svelte@5.22.5:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
+      '@sveltejs/acorn-typescript': 1.0.5(acorn@8.14.1)
       '@types/estree': 1.0.6
-      acorn: 8.14.0
-      acorn-typescript: 1.4.13(acorn@8.14.0)
+      acorn: 8.14.1
       aria-query: 5.3.2
       axobject-query: 4.1.0
       clsx: 2.1.1
@@ -3416,11 +3423,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vaul-svelte@1.0.0-next.6(svelte@5.20.5):
+  vaul-svelte@1.0.0-next.6(svelte@5.22.5):
     dependencies:
-      runed: 0.23.4(svelte@5.20.5)
-      svelte: 5.20.5
-      svelte-toolbelt: 0.7.1(svelte@5.20.5)
+      runed: 0.23.4(svelte@5.22.5)
+      svelte: 5.22.5
+      svelte-toolbelt: 0.7.1(svelte@5.22.5)
 
   vfile-message@2.0.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,10 +80,10 @@ importers:
         version: 5.22.5
       svelte-check:
         specifier: ^4.1.4
-        version: 4.1.4(picomatch@4.0.2)(svelte@5.22.5)(typescript@5.7.3)
+        version: 4.1.4(picomatch@4.0.2)(svelte@5.22.5)(typescript@5.8.2)
       svelte-seo:
         specifier: ^1.6.1
-        version: 1.6.1(typescript@5.7.3)
+        version: 1.6.1(typescript@5.8.2)
       svelte-sonner:
         specifier: ^0.3.28
         version: 0.3.28(svelte@5.22.5)
@@ -100,8 +100,8 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.17)
       typescript:
-        specifier: ^5.7.3
-        version: 5.7.3
+        specifier: ^5.8.2
+        version: 5.8.2
       vaul-svelte:
         specifier: 1.0.0-next.6
         version: 1.0.0-next.6(svelte@5.22.5)
@@ -1812,8 +1812,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3180,9 +3180,9 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
-  schema-dts@1.1.2(typescript@5.7.3):
+  schema-dts@1.1.2(typescript@5.8.2):
     dependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   semver@7.7.1: {}
 
@@ -3281,7 +3281,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.1.4(picomatch@4.0.2)(svelte@5.22.5)(typescript@5.7.3):
+  svelte-check@4.1.4(picomatch@4.0.2)(svelte@5.22.5)(typescript@5.8.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.3
@@ -3289,7 +3289,7 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.22.5
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - picomatch
 
@@ -3301,9 +3301,9 @@ snapshots:
     dependencies:
       svelte: 5.22.5
 
-  svelte-seo@1.6.1(typescript@5.7.3):
+  svelte-seo@1.6.1(typescript@5.8.2):
     dependencies:
-      schema-dts: 1.1.2(typescript@5.7.3)
+      schema-dts: 1.1.2(typescript@5.8.2)
     transitivePeerDependencies:
       - typescript
 
@@ -3395,7 +3395,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.7.3: {}
+  typescript@5.8.2: {}
 
   ufo@1.5.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^8.5.2
         version: 8.5.2(svelte@5.20.5)
       lucide-svelte:
-        specifier: ^0.475.0
-        version: 0.475.0(svelte@5.20.5)
+        specifier: ^0.476.0
+        version: 0.476.0(svelte@5.20.5)
       mdsvex:
         specifier: ^0.12.3
         version: 0.12.3(svelte@5.20.5)
@@ -1320,8 +1320,8 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lucide-svelte@0.475.0:
-    resolution: {integrity: sha512-N5+hFTPHaZe9HhqJDxxxODfYuOmI6v+JIowzERcea/uxytN/JZlehVTcINBNp8wMo7l6ov1Jf5srrDbkI/WsJg==}
+  lucide-svelte@0.476.0:
+    resolution: {integrity: sha512-Ph6zoMWjQVJibDrR+DJoT7LR2uEKLPzzGo886OLRk+nCJZESJUvoCWXk0uE6Y9aaamaSFAdI1Cpwslgzk3YYdQ==}
     peerDependencies:
       svelte: ^3 || ^4 || ^5.0.0-next.42
 
@@ -2905,7 +2905,7 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lucide-svelte@0.475.0(svelte@5.20.5):
+  lucide-svelte@0.476.0(svelte@5.20.5):
     dependencies:
       svelte: 5.20.5
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@fontsource/inter':
-        specifier: ^5.1.1
-        version: 5.1.1
+        specifier: ^5.2.5
+        version: 5.2.5
       embla-carousel-autoplay:
         specifier: ^8.5.2
         version: 8.5.2(embla-carousel@8.5.2)
@@ -618,8 +618,8 @@ packages:
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
-  '@fontsource/inter@5.1.1':
-    resolution: {integrity: sha512-weN3E+rq0Xb3Z93VHJ+Rc7WOQX9ETJPTAJ+gDcaMHtjft67L58sfS65rAjC5tZUXQ2FdZ/V1/sSzCwZ6v05kJw==}
+  '@fontsource/inter@5.2.5':
+    resolution: {integrity: sha512-kbsPKj0S4p44JdYRFiW78Td8Ge2sBVxi/PIBwmih+RpSXUdvS9nbs1HIiuUSPtRMi14CqLEZ/fbk7dj7vni1Sg==}
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -2238,7 +2238,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
-  '@fontsource/inter@5.1.1': {}
+  '@fontsource/inter@5.2.5': {}
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^8.5.2
         version: 8.5.2(svelte@5.22.5)
       lucide-svelte:
-        specifier: ^0.476.0
-        version: 0.476.0(svelte@5.22.5)
+        specifier: ^0.479.0
+        version: 0.479.0(svelte@5.22.5)
       mdsvex:
         specifier: ^0.12.3
         version: 0.12.3(svelte@5.22.5)
@@ -1325,8 +1325,8 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lucide-svelte@0.476.0:
-    resolution: {integrity: sha512-Ph6zoMWjQVJibDrR+DJoT7LR2uEKLPzzGo886OLRk+nCJZESJUvoCWXk0uE6Y9aaamaSFAdI1Cpwslgzk3YYdQ==}
+  lucide-svelte@0.479.0:
+    resolution: {integrity: sha512-epCj6WL86ykxg7oCQTmPEth5e11pwJUzIfG9ROUsWsTP+WPtb3qat+VmAjfx/r4TRW7memTFcbTPvMrZvKthqw==}
     peerDependencies:
       svelte: ^3 || ^4 || ^5.0.0-next.42
 
@@ -2912,7 +2912,7 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lucide-svelte@0.476.0(svelte@5.22.5):
+  lucide-svelte@0.479.0(svelte@5.22.5):
     dependencies:
       svelte: 5.22.5
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,14 +67,14 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1(svelte@5.22.5)
       prettier:
-        specifier: ^3.5.2
-        version: 3.5.2
+        specifier: ^3.5.3
+        version: 3.5.3
       prettier-plugin-svelte:
         specifier: ^3.3.3
-        version: 3.3.3(prettier@3.5.2)(svelte@5.22.5)
+        version: 3.3.3(prettier@3.5.3)(svelte@5.22.5)
       prettier-plugin-tailwindcss:
         specifier: ^0.6.11
-        version: 0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.2)(svelte@5.22.5))(prettier@3.5.2)
+        version: 0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.22.5))(prettier@3.5.3)
       svelte:
         specifier: ^5.22.5
         version: 5.22.5
@@ -1575,8 +1575,8 @@ packages:
       prettier-plugin-svelte:
         optional: true
 
-  prettier@3.5.2:
-    resolution: {integrity: sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==}
+  prettier@3.5.3:
+    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3083,18 +3083,18 @@ snapshots:
 
   preact@10.26.4: {}
 
-  prettier-plugin-svelte@3.3.3(prettier@3.5.2)(svelte@5.22.5):
+  prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.22.5):
     dependencies:
-      prettier: 3.5.2
+      prettier: 3.5.3
       svelte: 5.22.5
 
-  prettier-plugin-tailwindcss@0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.2)(svelte@5.22.5))(prettier@3.5.2):
+  prettier-plugin-tailwindcss@0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.22.5))(prettier@3.5.3):
     dependencies:
-      prettier: 3.5.2
+      prettier: 3.5.3
     optionalDependencies:
-      prettier-plugin-svelte: 3.3.3(prettier@3.5.2)(svelte@5.22.5)
+      prettier-plugin-svelte: 3.3.3(prettier@3.5.3)(svelte@5.22.5)
 
-  prettier@3.5.2: {}
+  prettier@3.5.3: {}
 
   printable-characters@1.0.42: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.5.3)
       bits-ui:
-        specifier: 1.3.2
-        version: 1.3.2(svelte@5.20.5)
+        specifier: 1.3.4
+        version: 1.3.4(svelte@5.20.5)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -998,8 +998,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  bits-ui@1.3.2:
-    resolution: {integrity: sha512-27fg/O71yqYmDaDf/opInylQYJjBNlFw3Ari0mXKLA6UrQpRvY62EsAid8s+ci/wYrGZMvHpzNJ69t15ycBHTw==}
+  bits-ui@1.3.4:
+    resolution: {integrity: sha512-hmrYbmb5D3ecRHP9GWTlkoo/9IGsPwMCmy3dAPKAfztG/NhWk49JcpuPbWi/eIggetVnv5nYrFp3N8zWscePCA==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.11.0
@@ -2559,7 +2559,7 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  bits-ui@1.3.2(svelte@5.20.5):
+  bits-ui@1.3.4(svelte@5.20.5):
     dependencies:
       '@floating-ui/core': 1.6.9
       '@floating-ui/dom': 1.6.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^3.12.7
         version: 3.12.7
       posthog-js:
-        specifier: ^1.224.0
-        version: 1.224.0(@rrweb/types@2.0.0-alpha.17)
+        specifier: ^1.227.0
+        version: 1.227.0(@rrweb/types@2.0.0-alpha.17)
       svelte-material-icons:
         specifier: ^3.0.5
         version: 3.0.5(svelte@5.20.5)
@@ -1067,8 +1067,8 @@ packages:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
-  core-js@3.40.0:
-    resolution: {integrity: sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==}
+  core-js@3.41.0:
+    resolution: {integrity: sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1412,8 +1412,8 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
-  ohash@1.1.4:
-    resolution: {integrity: sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g==}
+  ohash@1.1.6:
+    resolution: {integrity: sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -1501,13 +1501,13 @@ packages:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-js@1.224.0:
-    resolution: {integrity: sha512-JT1XQQeYs0CKb4lU2vujmeLTDLWc61I5lT7d6oG/H/cnCpXAqBi5rMuCFFeotHeMy3hqJ/Tpu3eAPFE2p5ErHA==}
+  posthog-js@1.227.0:
+    resolution: {integrity: sha512-xdXpBI+6SJDG3vUSxW3KH8o4B5CrHz0Y95anSaHjIzkEeRd9NbTTDku/Hy9lLt1+8tkiwvsh6fYi7jS1UBHL/g==}
     peerDependencies:
       '@rrweb/types': 2.0.0-alpha.17
 
-  preact@10.26.2:
-    resolution: {integrity: sha512-0gNmv4qpS9HaN3+40CLBAnKe0ZfyE4ZWo5xKlC1rVrr0ckkEvJvAQqKaHANdFKsGstoxrY4AItZ7kZSGVoVjgg==}
+  preact@10.26.4:
+    resolution: {integrity: sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w==}
 
   prettier-plugin-svelte@3.3.3:
     resolution: {integrity: sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==}
@@ -2633,7 +2633,7 @@ snapshots:
 
   cookie@0.6.0: {}
 
-  core-js@3.40.0: {}
+  core-js@3.41.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2994,7 +2994,7 @@ snapshots:
 
   object-hash@3.0.0: {}
 
-  ohash@1.1.4: {}
+  ohash@1.1.6: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -3066,15 +3066,15 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-js@1.224.0(@rrweb/types@2.0.0-alpha.17):
+  posthog-js@1.227.0(@rrweb/types@2.0.0-alpha.17):
     dependencies:
       '@rrweb/types': 2.0.0-alpha.17
-      core-js: 3.40.0
+      core-js: 3.41.0
       fflate: 0.4.8
-      preact: 10.26.2
+      preact: 10.26.4
       web-vitals: 4.2.4
 
-  preact@10.26.2: {}
+  preact@10.26.4: {}
 
   prettier-plugin-svelte@3.3.3(prettier@3.5.2)(svelte@5.20.5):
     dependencies:
@@ -3400,7 +3400,7 @@ snapshots:
     dependencies:
       defu: 6.1.4
       mlly: 1.7.4
-      ohash: 1.1.4
+      ohash: 1.1.6
       pathe: 1.1.2
       ufo: 1.5.4
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -64,10 +64,11 @@
 	}
 
 	let handleScroll = () => {};
+	let nextThing = () => {};
 
 	// Constants
 	const SIDEBAR_SCROLL_THRESHOLD = 100;
-	const THINGS_ROTATION_INTERVAL = 1600;
+	const THINGS_ROTATION_INTERVAL = 3000;
 	const HERO_ANIMATION_DELAY = 0.3;
 	const BLUR_AMOUNT = '12px';
 
@@ -116,18 +117,27 @@
 		}
 
 		// Loop through the things
-		const things = document.getElementById('things');
-		const thingsChildren = things?.children;
-		if (thingsChildren) {
-			let i = 0;
-			setInterval(() => {
+
+		let i = 0;
+
+		nextThing = () => {
+			const things = document.getElementById('things');
+			const thingsChildren = things?.children;
+
+			if (thingsChildren) {
 				thingsChildren[i].classList.add('opacity-0', 'blur-md', 'scale-50');
 				thingsChildren[i].classList.remove('scale-100');
 				i = (i + 1) % thingsChildren.length;
 				thingsChildren[i].classList.remove('opacity-0', 'blur-md', 'scale-50');
 				thingsChildren[i].classList.add('scale-100');
-			}, THINGS_ROTATION_INTERVAL);
-		}
+			}
+		};
+
+		setTimeout(() => {
+			nextThing();
+
+			setInterval(nextThing, THINGS_ROTATION_INTERVAL);
+		}, 1600);
 
 		// Register scrolltrigger plugin
 		gsap.registerPlugin(ScrollTrigger);
@@ -194,14 +204,21 @@
 		</div>
 		<div class="flex flex-row gap-2 text-2xl opacity-100 duration-500 lg:text-4xl">
 			<span class="secondaryherotext">and</span> <span class="secondaryherotext">I</span>
-			<div id="things" class="[&>*]:filter-blur-5 [&>*]:absolute [&>*]:duration-300">
+			<a
+				id="things"
+				class="[&>*]:filter-blur-5 [&>*]:absolute [&>*]:duration-300"
+				onclick={nextThing}
+				onkeydown={(e) => e.key === 'Enter' && nextThing()}
+				role="button"
+				tabindex="0"
+			>
 				<span class="scale-50 opacity-0 blur-md">code stuff</span>
 				<span class="scale-50 opacity-0 blur-md">build for the web</span>
 				<span class="scale-50 opacity-0 blur-md">make games</span>
 				<span class="scale-50 opacity-0 blur-md">mess with ai</span>
 				<span class="scale-50 opacity-0 blur-md">take photos</span>
 				<span class="scale-50 opacity-0 blur-md">use arch btw</span>
-			</div>
+			</a>
 		</div>
 	</div>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -171,7 +171,7 @@
 	});
 </script>
 
-<SvelteSeo title="Ingo" description="Hi, I'm Ingo, and I develop websites" />
+<SvelteSeo title="Ingo" description="Hi, I'm Ingo, and I build for the web" />
 
 <!-- Hero Section -->
 
@@ -195,10 +195,11 @@
 		<div class="flex flex-row gap-2 text-2xl opacity-100 duration-500 lg:text-4xl">
 			<span class="secondaryherotext">and</span> <span class="secondaryherotext">I</span>
 			<div id="things" class="[&>*]:filter-blur-5 [&>*]:absolute [&>*]:duration-300">
-				<span class="scale-50 opacity-0 blur-md">develop websites</span>
 				<span class="scale-50 opacity-0 blur-md">code stuff</span>
+				<span class="scale-50 opacity-0 blur-md">build for the web</span>
 				<span class="scale-50 opacity-0 blur-md">make games</span>
 				<span class="scale-50 opacity-0 blur-md">mess with ai</span>
+				<span class="scale-50 opacity-0 blur-md">take photos</span>
 				<span class="scale-50 opacity-0 blur-md">use arch btw</span>
 			</div>
 		</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -90,38 +90,6 @@
 		stagger: 0.1
 	};
 
-	// Helper function to setup hero animations
-	function setupHeroAnimations(timeline: gsap.core.Timeline) {
-		timeline
-			.from('.herotext', heroTextAnimation, 0.3)
-			.from('.secondaryherotext', secondaryHeroTextAnimation, 1.2)
-			.from(
-				'#hero-sidebar-trigger',
-				{
-					opacity: 0,
-					duration: 0.5,
-					x: -50,
-					ease: 'expo.out'
-				},
-				0
-			);
-	}
-
-	// Helper function to setup scroll triggers
-	function setupScrollTriggers() {
-		gsap.from('#projects > *', {
-			opacity: 0,
-			y: 50,
-			duration: 0.5,
-			ease: 'expo.out',
-			stagger: 0.1,
-			scrollTrigger: {
-				trigger: '#projects',
-				scrub: true
-			}
-		});
-	}
-
 	onMount(() => {
 		let openedSidebar = false;
 
@@ -165,9 +133,32 @@
 		gsap.registerPlugin(ScrollTrigger);
 
 		gsapctx = gsap.context(() => {
-			let heroTimeline = gsap.timeline({ delay: HERO_ANIMATION_DELAY });
-			setupHeroAnimations(heroTimeline);
-			setupScrollTriggers();
+			gsap
+				.timeline({ delay: HERO_ANIMATION_DELAY })
+				.from('.herotext', heroTextAnimation, 0.3)
+				.from('.secondaryherotext', secondaryHeroTextAnimation, 1.2)
+				.from(
+					'#hero-sidebar-trigger',
+					{
+						opacity: 0,
+						duration: 0.5,
+						x: -50,
+						ease: 'expo.out'
+					},
+					0
+				);
+
+			gsap.from('#projects > *', {
+				opacity: 0,
+				y: 50,
+				duration: 0.5,
+				ease: 'expo.out',
+				stagger: 0.1,
+				scrollTrigger: {
+					trigger: '#projects',
+					scrub: true
+				}
+			});
 		});
 	});
 


### PR DESCRIPTION
This pull request updates several dependencies in the `package.json` and `pnpm-lock.yaml` files to their latest versions. These updates ensure that the project uses the most recent and secure versions of these packages, which can include performance improvements, bug fixes, and new features.

Dependency updates:

* Updated `bits-ui` from `1.3.2` to `1.3.4` in `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L22-R49) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1001-R1007)
* Updated `lucide-svelte` from `0.475.0` to `0.479.0` in `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L22-R49) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1323-R1329)
* Updated `prettier` from `3.5.2` to `3.5.3` in `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L22-R49) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1573-R1579)
* Updated `svelte` from `5.20.5` to `5.22.5` in `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L22-R49) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1760-R1766)
* Updated `typescript` from `5.7.3` to `5.8.2` in `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L22-R49) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1810-R1816)

These updates are reflected in both `package.json` and `pnpm-lock.yaml` to ensure consistency and proper dependency resolution.